### PR TITLE
Update API to use user_id as identifier and add OpenAPI documentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,9 @@ gem "thruster", require: false
 
 gem "dotenv-rails"
 
+# Multi-tenancy
+gem 'acts_as_tenant'
+
 group :development, :test do
   gem "pry"
 

--- a/Gemfile
+++ b/Gemfile
@@ -38,11 +38,11 @@ gem "thruster", require: false
 gem "dotenv-rails"
 
 # Multi-tenancy
-gem 'acts_as_tenant'
+gem "acts_as_tenant"
 
 # API Documentation
-gem 'rswag-api'
-gem 'rswag-ui'
+gem "rswag-api"
+gem "rswag-ui"
 
 group :development, :test do
   gem "pry"

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,10 @@ gem "dotenv-rails"
 # Multi-tenancy
 gem 'acts_as_tenant'
 
+# API Documentation
+gem 'rswag-api'
+gem 'rswag-ui'
+
 group :development, :test do
   gem "pry"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,8 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    acts_as_tenant (1.0.1)
+      rails (>= 6.0)
     ast (2.4.3)
     base64 (0.2.0)
     bcrypt_pbkdf (1.1.1)
@@ -351,6 +353,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  acts_as_tenant
   bootsnap
   brakeman
   database_cleaner-active_record

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,6 +264,12 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.3)
+    rswag-api (2.16.0)
+      activesupport (>= 5.2, < 8.1)
+      railties (>= 5.2, < 8.1)
+    rswag-ui (2.16.0)
+      actionpack (>= 5.2, < 8.1)
+      railties (>= 5.2, < 8.1)
     rubocop (1.75.5)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -366,6 +372,8 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 8.0.1)
   rspec-rails
+  rswag-api
+  rswag-ui
   rubocop-rails-omakase
   shoulda-matchers
   solid_cable

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This architecture enables **safe multi-client usage**, scales with workload, and
 
 - [x] Initialize Rails 7 API-only app with PostgreSQL
 - [x] Set up `Client` model with token-based auth
-- [x] Add middleware for tenant switching using `apartment` gem
+- [x] Add middleware for tenant switching using `act_as_tanent` gem
 - [x] Create `User` model (per-tenant)
 - [x] Implement `Transaction` model and points-earning rules:
   - $100 = 10 points

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,62 @@
+module Api
+  module V1
+    class UsersController < ApplicationController
+      before_action :set_user, only: [:show, :update, :destroy]
+      
+      # GET /api/v1/users
+      def index
+        # acts_as_tenant automatically scopes this to current_client
+        @users = User.all
+        
+        render json: @users
+      end
+      
+      # GET /api/v1/users/:user_id
+      def show
+        render json: @user
+      end
+      
+      # POST /api/v1/users
+      def create
+        @user = User.new(user_params)
+        
+        # No need to set client_id, acts_as_tenant does this automatically
+        # @user.client = current_client
+        
+        if @user.save
+          render json: @user, status: :created
+        else
+          render json: { errors: @user.errors }, status: :unprocessable_entity
+        end
+      end
+      
+      # PATCH/PUT /api/v1/users/:user_id
+      def update
+        if @user.update(user_params)
+          render json: @user
+        else
+          render json: { errors: @user.errors }, status: :unprocessable_entity
+        end
+      end
+      
+      # DELETE /api/v1/users/:user_id
+      def destroy
+        @user.destroy
+        head :no_content
+      end
+      
+      private
+      
+      def set_user
+        # acts_as_tenant automatically scopes this to current_client
+        @user = User.find_by!(user_id: params[:user_id])
+      rescue ActiveRecord::RecordNotFound
+        render json: { error: "User not found" }, status: :not_found
+      end
+      
+      def user_params
+        params.require(:user).permit(:user_id, :birth_date, :joining_date)
+      end
+    end
+  end
+end 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,35 +1,35 @@
 module Api
   module V1
     class UsersController < ApplicationController
-      before_action :set_user, only: [:show, :update, :destroy]
-      
+      before_action :set_user, only: [ :show, :update, :destroy ]
+
       # GET /api/v1/users
       def index
         # acts_as_tenant automatically scopes this to current_client
         @users = User.all
-        
+
         render json: @users
       end
-      
+
       # GET /api/v1/users/:user_id
       def show
         render json: @user
       end
-      
+
       # POST /api/v1/users
       def create
         @user = User.new(user_params)
-        
+
         # No need to set client_id, acts_as_tenant does this automatically
         # @user.client = current_client
-        
+
         if @user.save
           render json: @user, status: :created
         else
           render json: { errors: @user.errors }, status: :unprocessable_entity
         end
       end
-      
+
       # PATCH/PUT /api/v1/users/:user_id
       def update
         if @user.update(user_params)
@@ -38,25 +38,25 @@ module Api
           render json: { errors: @user.errors }, status: :unprocessable_entity
         end
       end
-      
+
       # DELETE /api/v1/users/:user_id
       def destroy
         @user.destroy
         head :no_content
       end
-      
+
       private
-      
+
       def set_user
         # acts_as_tenant automatically scopes this to current_client
         @user = User.find_by!(user_id: params[:user_id])
       rescue ActiveRecord::RecordNotFound
         render json: { error: "User not found" }, status: :not_found
       end
-      
+
       def user_params
         params.require(:user).permit(:user_id, :birth_date, :joining_date)
       end
     end
   end
-end 
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -21,8 +21,6 @@ module Api
         @user = User.new(user_params)
 
         # No need to set client_id, acts_as_tenant does this automatically
-        # @user.client = current_client
-
         if @user.save
           render json: @user, status: :created
         else

--- a/app/controllers/api_docs_controller.rb
+++ b/app/controllers/api_docs_controller.rb
@@ -1,0 +1,24 @@
+class ApiDocsController < ActionController::Base
+  include Swagger::Blocks
+
+  swagger_root do
+    key :swagger, '2.0'
+    info do
+      key :version, '1.0.0'
+      key :title, 'Loyalty Rewards API'
+      key :description, 'API for managing user loyalty rewards'
+      contact do
+        key :name, 'API Support'
+        key :email, 'support@example.com'
+      end
+    end
+    key :host, 'api.example.com'
+    key :basePath, '/api/v1'
+    key :consumes, ['application/json']
+    key :produces, ['application/json']
+  end
+
+  def index
+    render json: Swagger::Blocks.build_root_json([self.class])
+  end
+end 

--- a/app/controllers/api_docs_controller.rb
+++ b/app/controllers/api_docs_controller.rb
@@ -2,23 +2,23 @@ class ApiDocsController < ActionController::Base
   include Swagger::Blocks
 
   swagger_root do
-    key :swagger, '2.0'
+    key :swagger, "2.0"
     info do
-      key :version, '1.0.0'
-      key :title, 'Loyalty Rewards API'
-      key :description, 'API for managing user loyalty rewards'
+      key :version, "1.0.0"
+      key :title, "Loyalty Rewards API"
+      key :description, "API for managing user loyalty rewards"
       contact do
-        key :name, 'API Support'
-        key :email, 'support@example.com'
+        key :name, "API Support"
+        key :email, "support@example.com"
       end
     end
-    key :host, 'api.example.com'
-    key :basePath, '/api/v1'
-    key :consumes, ['application/json']
-    key :produces, ['application/json']
+    key :host, "api.example.com"
+    key :basePath, "/api/v1"
+    key :consumes, [ "application/json" ]
+    key :produces, [ "application/json" ]
   end
 
   def index
-    render json: Swagger::Blocks.build_root_json([self.class])
+    render json: Swagger::Blocks.build_root_json([ self.class ])
   end
-end 
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,9 @@ class ApplicationController < ActionController::API
   def authenticate_client!
     unless current_client
       render json: { error: "Unauthorized" }, status: :unauthorized
+    else
+      # Set the current tenant based on client's subdomain
+      ActsAsTenant.current_tenant = current_client
     end
   end
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,10 +1,3 @@
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
-
-  # Don't set acts_as_tenant at this level
-  # Instead, add it explicitly to each model that should be scoped by tenant
-  # Example:
-  #   class SomeModel < ApplicationRecord
-  #     acts_as_tenant(:client)
-  #   end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,6 +1,6 @@
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
-  
+
   # Don't set acts_as_tenant at this level
   # Instead, add it explicitly to each model that should be scoped by tenant
   # Example:

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,10 @@
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
+  
+  # Don't set acts_as_tenant at this level
+  # Instead, add it explicitly to each model that should be scoped by tenant
+  # Example:
+  #   class SomeModel < ApplicationRecord
+  #     acts_as_tenant(:client)
+  #   end
 end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -1,10 +1,17 @@
 class Client < ApplicationRecord
   has_secure_token :api_token, length: 24
 
+  # Associations
+  has_many :users, dependent: :destroy
+  
+  # Validations
   validates :name, presence: true
   validates :subdomain, presence: true, uniqueness: true,
     format: {
         with: /\A[A-Za-z0-9](?:[A-Za-z0-9_-]*[A-Za-z0-9])?\z/,
         message: "only allows letters, numbers, hyphens, and underscores (cannot start or end with a hyphen or underscore)"
     }
+    
+  # Client acts as the tenant model for multi-tenancy
+  # This will be used by ActsAsTenant to set current_tenant
 end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -3,7 +3,7 @@ class Client < ApplicationRecord
 
   # Associations
   has_many :users, dependent: :destroy
-  
+
   # Validations
   validates :name, presence: true
   validates :subdomain, presence: true, uniqueness: true,
@@ -11,7 +11,7 @@ class Client < ApplicationRecord
         with: /\A[A-Za-z0-9](?:[A-Za-z0-9_-]*[A-Za-z0-9])?\z/,
         message: "only allows letters, numbers, hyphens, and underscores (cannot start or end with a hyphen or underscore)"
     }
-    
+
   # Client acts as the tenant model for multi-tenancy
   # This will be used by ActsAsTenant to set current_tenant
 end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -1,17 +1,15 @@
 class Client < ApplicationRecord
+  # Client acts as the tenant model for multi-tenancy
+  # This will be used by ActsAsTenant to set current_tenant
+  
   has_secure_token :api_token, length: 24
 
-  # Associations
   has_many :users, dependent: :destroy
 
-  # Validations
   validates :name, presence: true
   validates :subdomain, presence: true, uniqueness: true,
     format: {
         with: /\A[A-Za-z0-9](?:[A-Za-z0-9_-]*[A-Za-z0-9])?\z/,
         message: "only allows letters, numbers, hyphens, and underscores (cannot start or end with a hyphen or underscore)"
     }
-
-  # Client acts as the tenant model for multi-tenancy
-  # This will be used by ActsAsTenant to set current_tenant
 end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -1,7 +1,7 @@
 class Client < ApplicationRecord
   # Client acts as the tenant model for multi-tenancy
   # This will be used by ActsAsTenant to set current_tenant
-  
+
   has_secure_token :api_token, length: 24
 
   has_many :users, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,5 @@
 class User < ApplicationRecord
-  # Multi-tenancy
   acts_as_tenant :client
 
-  # Validations
   validates :user_id, presence: true, uniqueness: { scope: :client_id }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   # Multi-tenancy
   acts_as_tenant :client
-  
+
   # Validations
   validates :user_id, presence: true, uniqueness: { scope: :client_id }
-end 
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,7 @@
+class User < ApplicationRecord
+  # Multi-tenancy
+  acts_as_tenant :client
+  
+  # Validations
+  validates :user_id, presence: true, uniqueness: { scope: :client_id }
+end 

--- a/config/initializers/acts_as_tenant.rb
+++ b/config/initializers/acts_as_tenant.rb
@@ -2,7 +2,6 @@
 # https://github.com/ErwinM/acts_as_tenant
 
 ActsAsTenant.configure do |config|
-  # Whether to include validation that checks if a tenant is always provided
   # When set to true, an error will be raised if a tenant is not provided when accessing a model that is scoped by tenant
   config.require_tenant = true
 end

--- a/config/initializers/acts_as_tenant.rb
+++ b/config/initializers/acts_as_tenant.rb
@@ -1,0 +1,8 @@
+# Configuration for acts_as_tenant
+# https://github.com/ErwinM/acts_as_tenant
+
+ActsAsTenant.configure do |config|
+  # Whether to include validation that checks if a tenant is always provided
+  # When set to true, an error will be raised if a tenant is not provided when accessing a model that is scoped by tenant
+  config.require_tenant = true
+end

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,3 @@
+Rswag::Api.configure do |c|
+  c.swagger_root = Rails.root.to_s + '/swagger'
+end 

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,3 +1,3 @@
 Rswag::Api.configure do |c|
-  c.swagger_root = Rails.root.to_s + '/swagger'
-end 
+  c.swagger_root = Rails.root.to_s + "/swagger"
+end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -2,5 +2,5 @@ Rswag::Ui.configure do |c|
   # List the Swagger endpoints that you want to be documented through Swagger UI
   # The first parameter is the path (absolute or relative to the UI host) to the corresponding
   # endpoint and the second is a title that will be displayed in the document selector
-  c.swagger_endpoint '/api-docs/v1/swagger.json', 'Loyalty Rewards API V1 Docs'
-end 
+  c.swagger_endpoint "/api-docs/v1/swagger.json", "Loyalty Rewards API V1 Docs"
+end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,0 +1,6 @@
+Rswag::Ui.configure do |c|
+  # List the Swagger endpoints that you want to be documented through Swagger UI
+  # The first parameter is the path (absolute or relative to the UI host) to the corresponding
+  # endpoint and the second is a title that will be displayed in the document selector
+  c.swagger_endpoint '/api-docs/v1/swagger.json', 'Loyalty Rewards API V1 Docs'
+end 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,8 +11,8 @@ Rails.application.routes.draw do
       resources :users, param: :user_id
     end
   end
-  
+
   # Mount Swagger UI and API documentation
-  mount Rswag::Ui::Engine => '/api-docs'
-  mount Rswag::Api::Engine => '/api-docs'
+  mount Rswag::Ui::Engine => "/api-docs"
+  mount Rswag::Api::Engine => "/api-docs"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get "ping", to: "ping#index"
+      resources :users, param: :user_id
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
 
@@ -12,4 +11,8 @@ Rails.application.routes.draw do
       resources :users, param: :user_id
     end
   end
+  
+  # Mount Swagger UI and API documentation
+  mount Rswag::Ui::Engine => '/api-docs'
+  mount Rswag::Api::Engine => '/api-docs'
 end

--- a/db/migrate/20250513000001_create_users.rb
+++ b/db/migrate/20250513000001_create_users.rb
@@ -1,0 +1,17 @@
+class CreateUsers < ActiveRecord::Migration[8.0]
+  def change
+    create_table :users do |t|
+      t.string :user_id, null: false
+      t.datetime :joining_date, null: true
+      t.datetime :birth_date, null: true
+      t.integer :points, default: 0, null: false
+      
+      t.references :client, null: false, foreign_key: true
+      
+      t.timestamps
+    end
+    
+    # Add indexes to speed up queries
+    add_index :users, [:client_id, :user_id], unique: true
+  end
+end 

--- a/db/migrate/20250513000001_create_users.rb
+++ b/db/migrate/20250513000001_create_users.rb
@@ -5,13 +5,13 @@ class CreateUsers < ActiveRecord::Migration[8.0]
       t.datetime :joining_date, null: true
       t.datetime :birth_date, null: true
       t.integer :points, default: 0, null: false
-      
+
       t.references :client, null: false, foreign_key: true
-      
+
       t.timestamps
     end
-    
+
     # Add indexes to speed up queries
-    add_index :users, [:client_id, :user_id], unique: true
+    add_index :users, [ :client_id, :user_id ], unique: true
   end
-end 
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_12_010131) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_13_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -22,4 +22,18 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_12_010131) do
     t.datetime "updated_at", null: false
     t.index ["api_token"], name: "index_clients_on_api_token", unique: true
   end
+
+  create_table "users", force: :cascade do |t|
+    t.string "user_id", null: false
+    t.datetime "joining_date"
+    t.datetime "birth_date"
+    t.integer "points", default: 0, null: false
+    t.bigint "client_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["client_id", "user_id"], name: "index_users_on_client_id_and_user_id", unique: true
+    t.index ["client_id"], name: "index_users_on_client_id"
+  end
+
+  add_foreign_key "users", "clients"
 end

--- a/lib/tasks/swagger.rake
+++ b/lib/tasks/swagger.rake
@@ -1,19 +1,19 @@
-require 'yaml'
-require 'json'
+require "yaml"
+require "json"
 
 namespace :swagger do
-  desc 'Convert YAML to JSON for Swagger UI'
+  desc "Convert YAML to JSON for Swagger UI"
   task generate_json: :environment do
-    swagger_dir = Rails.root.join('swagger')
-    Dir.glob(File.join(swagger_dir, '**', '*.yaml')).each do |yaml_file|
+    swagger_dir = Rails.root.join("swagger")
+    Dir.glob(File.join(swagger_dir, "**", "*.yaml")).each do |yaml_file|
       yaml_content = YAML.load_file(yaml_file)
-      json_file = yaml_file.sub(/\.yaml\z/, '.json')
-      
-      File.open(json_file, 'w') do |file|
+      json_file = yaml_file.sub(/\.yaml\z/, ".json")
+
+      File.open(json_file, "w") do |file|
         file.write(JSON.pretty_generate(yaml_content))
       end
-      
+
       puts "Generated #{json_file} from #{yaml_file}"
     end
   end
-end 
+end

--- a/lib/tasks/swagger.rake
+++ b/lib/tasks/swagger.rake
@@ -1,0 +1,19 @@
+require 'yaml'
+require 'json'
+
+namespace :swagger do
+  desc 'Convert YAML to JSON for Swagger UI'
+  task generate_json: :environment do
+    swagger_dir = Rails.root.join('swagger')
+    Dir.glob(File.join(swagger_dir, '**', '*.yaml')).each do |yaml_file|
+      yaml_content = YAML.load_file(yaml_file)
+      json_file = yaml_file.sub(/\.yaml\z/, '.json')
+      
+      File.open(json_file, 'w') do |file|
+        file.write(JSON.pretty_generate(yaml_content))
+      end
+      
+      puts "Generated #{json_file} from #{yaml_file}"
+    end
+  end
+end 

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::UsersController, type: :controller do
-  # Use the sequence in factory instead of hardcoding subdomain
   let!(:client1) { create(:client, name: 'Client One') }
   let!(:client2) { create(:client, name: 'Client Two') }
   
@@ -15,7 +14,6 @@ RSpec.describe Api::V1::UsersController, type: :controller do
   
   describe 'when authenticated as client1' do
     before do
-      # Create test users within their tenant context
       ActsAsTenant.with_tenant(client1) do
         @client1_user1 = create(:user, user_id: 'user1@client1.com')
         @client1_user2 = create(:user, user_id: 'user2@client1.com')

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -1,0 +1,180 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::UsersController, type: :controller do
+  # Use the sequence in factory instead of hardcoding subdomain
+  let!(:client1) { create(:client, name: 'Client One') }
+  let!(:client2) { create(:client, name: 'Client Two') }
+  
+  before(:all) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+  
+  after(:all) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+  
+  describe 'when authenticated as client1' do
+    before do
+      # Create test users within their tenant context
+      ActsAsTenant.with_tenant(client1) do
+        @client1_user1 = create(:user, user_id: 'user1@client1.com')
+        @client1_user2 = create(:user, user_id: 'user2@client1.com')
+      end
+      
+      ActsAsTenant.with_tenant(client2) do
+        @client2_user = create(:user, user_id: 'user@client2.com')
+      end
+      
+      # Mock authentication methods
+      allow_any_instance_of(ApplicationController).to receive(:current_client).and_return(client1)
+      allow_any_instance_of(ApplicationController).to receive(:authenticate_client!)
+        .and_wrap_original do |m, *args|
+          ActsAsTenant.current_tenant = client1
+          true
+        end
+    end
+    
+    describe 'GET #index' do
+      it 'returns only users for client1' do
+        get :index
+        expect(response).to have_http_status(:ok)
+        
+        json_response = JSON.parse(response.body)
+        expect(json_response.length).to eq(2)
+        user_ids = json_response.map { |user| user['user_id'] }
+        expect(user_ids).to contain_exactly('user1@client1.com', 'user2@client1.com')
+      end
+    end
+    
+    describe 'GET #show' do
+      it 'returns the requested user for client1' do
+        get :show, params: { user_id: @client1_user1.user_id }
+        expect(response).to have_http_status(:ok)
+        
+        json_response = JSON.parse(response.body)
+        expect(json_response['user_id']).to eq('user1@client1.com')
+      end
+      
+      it 'cannot access users from client2' do
+        get :show, params: { user_id: @client2_user.user_id }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+    
+    describe 'POST #create' do
+      it 'creates a user associated with client1' do
+        user_params = {
+          user: {
+            user_id: 'new@client1.com',
+            birth_date: '1990-01-01',
+            joining_date: '2020-01-01'
+          }
+        }
+        
+        post :create, params: user_params
+        expect(response).to have_http_status(:created)
+        
+        json_response = JSON.parse(response.body)
+        expect(json_response['user_id']).to eq('new@client1.com')
+        expect(json_response['birth_date']).to include('1990-01-01')
+        expect(json_response['joining_date']).to include('2020-01-01')
+        
+        # Verify the user is associated with client1
+        ActsAsTenant.with_tenant(client1) do
+          new_user = User.find_by(user_id: 'new@client1.com')
+          expect(new_user.client).to eq(client1)
+        end
+      end
+    end
+    
+    describe 'PATCH/PUT #update' do
+      it 'updates the requested user' do
+        updated_params = {
+          user_id: @client1_user1.user_id,
+          user: {
+            birth_date: '1995-05-05'
+          }
+        }
+        
+        put :update, params: updated_params
+        expect(response).to have_http_status(:ok)
+        
+        json_response = JSON.parse(response.body)
+        expect(json_response['birth_date']).to include('1995-05-05')
+        
+        # Verify the database was updated
+        ActsAsTenant.with_tenant(client1) do
+          @client1_user1.reload
+          expect(@client1_user1.birth_date.to_s).to include('1995-05-05')
+        end
+      end
+      
+      it 'cannot update users from client2' do
+        updated_params = {
+          user_id: @client2_user.user_id,
+          user: {
+            birth_date: '1995-05-05'
+          }
+        }
+        
+        put :update, params: updated_params
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+    
+    describe 'DELETE #destroy' do
+      it 'destroys the requested user' do
+        expect {
+          delete :destroy, params: { user_id: @client1_user1.user_id }
+        }.to change { 
+          ActsAsTenant.with_tenant(client1) { User.count }
+        }.by(-1)
+        
+        expect(response).to have_http_status(:no_content)
+      end
+      
+      it 'cannot destroy users from client2' do
+        expect {
+          delete :destroy, params: { user_id: @client2_user.user_id }
+        }.not_to change {
+          ActsAsTenant.with_tenant(client2) { User.count }
+        }
+        
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+  
+  describe 'when authenticated as client2' do
+    before do
+      # Create test users within their tenant context
+      ActsAsTenant.with_tenant(client1) do
+        @client1_user1 = create(:user, user_id: 'user1@client1.com')
+        @client1_user2 = create(:user, user_id: 'user2@client1.com')
+      end
+      
+      ActsAsTenant.with_tenant(client2) do
+        @client2_user = create(:user, user_id: 'user@client2.com')
+      end
+      
+      # Mock authentication methods
+      allow_any_instance_of(ApplicationController).to receive(:current_client).and_return(client2)
+      allow_any_instance_of(ApplicationController).to receive(:authenticate_client!)
+        .and_wrap_original do |m, *args|
+          ActsAsTenant.current_tenant = client2
+          true
+        end
+    end
+    
+    describe 'GET #index' do
+      it 'returns only users for client2' do
+        get :index
+        expect(response).to have_http_status(:ok)
+        
+        json_response = JSON.parse(response.body)
+        expect(json_response.length).to eq(1)
+        expect(json_response[0]['user_id']).to eq('user@client2.com')
+      end
+    end
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :user do
+    user_id { Faker::Internet.email }
+    birth_date { Faker::Date.birthday(min_age: 18, max_age: 65) }
+    joining_date { Faker::Date.backward(days: 365) }
+    points { 0 }
+    
+    # This association will be set automatically by acts_as_tenant
+    # when a tenant is active, but we need it for testing
+    client
+  end
+end 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  # Create clients for testing
+  let!(:client1) { create(:client, name: 'Client 1', subdomain: 'client1') }
+  let!(:client2) { create(:client, name: 'Client 2', subdomain: 'client2') }
+  
+  describe 'validations' do
+    # Use around hook to ensure tenant is set for all tests in this block
+    around do |example|
+      ActsAsTenant.with_tenant(client1) do
+        example.run
+      end
+    end
+    
+    it { should validate_presence_of(:user_id) }
+    
+    it 'validates uniqueness of user_id scoped to client' do
+      # Create a user for client1
+      create(:user, user_id: 'test@example.com')
+      
+      # Same user_id for client1 should be invalid
+      user = build(:user, user_id: 'test@example.com')
+      expect(user).not_to be_valid
+      expect(user.errors[:user_id]).to include('has already been taken')
+      
+      # Clear the tenant for this specific test
+      ActsAsTenant.with_tenant(nil) do
+        # Set a different tenant
+        ActsAsTenant.with_tenant(client2) do
+          # Same user_id for client2 should be valid
+          user2 = build(:user, user_id: 'test@example.com')
+          expect(user2).to be_valid
+        end
+      end
+    end
+  end
+  
+  describe 'tenant scoping' do
+    before do
+      # Create users for different clients
+      ActsAsTenant.with_tenant(client1) do
+        create(:user, user_id: 'test@example.com')
+        create(:user, user_id: 'test2@example.com')
+      end
+      
+      ActsAsTenant.with_tenant(client2) do
+        create(:user, user_id: 'test@example.com')
+      end
+    end
+    
+    it 'scopes queries to the current tenant' do
+      # Using client1 as tenant should only see client1's users
+      ActsAsTenant.with_tenant(client1) do
+        expect(User.count).to eq(2)
+        expect(User.pluck(:user_id)).to contain_exactly('test@example.com', 'test2@example.com')
+      end
+      
+      # Using client2 as tenant should only see client2's users
+      ActsAsTenant.with_tenant(client2) do
+        expect(User.count).to eq(1)
+        expect(User.pluck(:user_id)).to contain_exactly('test@example.com')
+      end
+    end
+    
+    it 'automatically assigns tenant to new records' do
+      ActsAsTenant.with_tenant(client1) do
+        user = User.create(user_id: 'test3@example.com')
+        expect(user.client).to eq(client1)
+      end
+    end
+    
+    it 'prevents access to other tenants records' do
+      # Try to access a record from client2 while using client1 as tenant
+      user_from_client2 = nil
+      
+      ActsAsTenant.with_tenant(client2) do
+        user_from_client2 = User.first
+      end
+      
+      ActsAsTenant.with_tenant(client1) do
+        expect { User.find(user_from_client2.id) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end 

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -1,0 +1,390 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Loyalty Rewards API",
+    "description": "API for managing user loyalty rewards",
+    "version": "v1",
+    "contact": {
+      "email": "support@example.com"
+    }
+  },
+  "servers": [
+    {
+      "url": "{protocol}://{subdomain}.example.com/api/v1",
+      "variables": {
+        "protocol": {
+          "enum": [
+            "http",
+            "https"
+          ],
+          "default": "https"
+        },
+        "subdomain": {
+          "default": "client1",
+          "description": "Client subdomain for multi-tenant access"
+        }
+      }
+    }
+  ],
+  "paths": {
+    "/users": {
+      "get": {
+        "summary": "List all users",
+        "description": "Returns a list of all users for the current client",
+        "operationId": "listUsers",
+        "tags": [
+          "users"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of users",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/User"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a new user",
+        "description": "Creates a new user for the current client",
+        "operationId": "createUser",
+        "tags": [
+          "users"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "User created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      }
+    },
+    "/users/{user_id}": {
+      "parameters": [
+        {
+          "name": "user_id",
+          "in": "path",
+          "required": true,
+          "description": "Unique identifier for the user within the client",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "summary": "Get a specific user",
+        "description": "Returns a specific user by user_id",
+        "operationId": "getUser",
+        "tags": [
+          "users"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The requested user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "put": {
+        "summary": "Update a user",
+        "description": "Updates a user's information",
+        "operationId": "updateUser",
+        "tags": [
+          "users"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "User updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a user",
+        "description": "Deletes a specific user by user_id",
+        "operationId": "deleteUser",
+        "tags": [
+          "users"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "User deleted successfully"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/ping": {
+      "get": {
+        "summary": "API health check",
+        "description": "Returns a simple response to confirm the API is running",
+        "operationId": "ping",
+        "tags": [
+          "system"
+        ],
+        "responses": {
+          "200": {
+            "description": "API is operational",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "pong"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      }
+    },
+    "schemas": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64",
+            "readOnly": true,
+            "description": "Internal database ID"
+          },
+          "user_id": {
+            "type": "string",
+            "description": "Unique identifier for the user within the client"
+          },
+          "birth_date": {
+            "type": "string",
+            "format": "date",
+            "nullable": true,
+            "description": "User's birth date"
+          },
+          "joining_date": {
+            "type": "string",
+            "format": "date",
+            "nullable": true,
+            "description": "Date when the user joined"
+          },
+          "points": {
+            "type": "integer",
+            "description": "User's loyalty points",
+            "default": 0
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          }
+        },
+        "required": [
+          "user_id"
+        ]
+      },
+      "UserInput": {
+        "type": "object",
+        "properties": {
+          "user_id": {
+            "type": "string",
+            "description": "Unique identifier for the user within the client"
+          },
+          "birth_date": {
+            "type": "string",
+            "format": "date",
+            "nullable": true,
+            "description": "User's birth date"
+          },
+          "joining_date": {
+            "type": "string",
+            "format": "date",
+            "nullable": true,
+            "description": "Date when the user joined"
+          }
+        },
+        "required": [
+          "user_id"
+        ]
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "BadRequest": {
+        "description": "Invalid request format",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "Missing or invalid authentication",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "Resource not found",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "UnprocessableEntity": {
+        "description": "Validation errors",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1,0 +1,251 @@
+openapi: 3.0.1
+info:
+  title: Loyalty Rewards API
+  description: API for managing user loyalty rewards
+  version: 'v1'
+  contact:
+    email: support@example.com
+servers:
+  - url: '{protocol}://{subdomain}.example.com/api/v1'
+    variables:
+      protocol:
+        enum:
+          - http
+          - https
+        default: https
+      subdomain:
+        default: client1
+        description: Client subdomain for multi-tenant access
+paths:
+  /users:
+    get:
+      summary: List all users
+      description: Returns a list of all users for the current client
+      operationId: listUsers
+      tags:
+        - users
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: A list of users
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+    post:
+      summary: Create a new user
+      description: Creates a new user for the current client
+      operationId: createUser
+      tags:
+        - users
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserInput'
+      responses:
+        '201':
+          description: User created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+  /users/{user_id}:
+    parameters:
+      - name: user_id
+        in: path
+        required: true
+        description: Unique identifier for the user within the client
+        schema:
+          type: string
+    get:
+      summary: Get a specific user
+      description: Returns a specific user by user_id
+      operationId: getUser
+      tags:
+        - users
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: The requested user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    put:
+      summary: Update a user
+      description: Updates a user's information
+      operationId: updateUser
+      tags:
+        - users
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserInput'
+      responses:
+        '200':
+          description: User updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+    delete:
+      summary: Delete a user
+      description: Deletes a specific user by user_id
+      operationId: deleteUser
+      tags:
+        - users
+      security:
+        - BearerAuth: []
+      responses:
+        '204':
+          description: User deleted successfully
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /ping:
+    get:
+      summary: API health check
+      description: Returns a simple response to confirm the API is running
+      operationId: ping
+      tags:
+        - system
+      responses:
+        '200':
+          description: API is operational
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "pong"
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          readOnly: true
+          description: Internal database ID
+        user_id:
+          type: string
+          description: Unique identifier for the user within the client
+        birth_date:
+          type: string
+          format: date
+          nullable: true
+          description: User's birth date
+        joining_date:
+          type: string
+          format: date
+          nullable: true
+          description: Date when the user joined
+        points:
+          type: integer
+          description: User's loyalty points
+          default: 0
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+        - user_id
+    UserInput:
+      type: object
+      properties:
+        user_id:
+          type: string
+          description: Unique identifier for the user within the client
+        birth_date:
+          type: string
+          format: date
+          nullable: true
+          description: User's birth date
+        joining_date:
+          type: string
+          format: date
+          nullable: true
+          description: Date when the user joined
+      required:
+        - user_id
+    Error:
+      type: object
+      properties:
+        error:
+          type: string
+        errors:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+  responses:
+    BadRequest:
+      description: Invalid request format
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    Unauthorized:
+      description: Missing or invalid authentication
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    UnprocessableEntity:
+      description: Validation errors
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error' 


### PR DESCRIPTION
**Overview**
This PR updates our API to use user_id as the primary identifier for users, replacing the internal database id. It also introduces comprehensive OpenAPI specifications and a Swagger UI for easy API exploration and documentation.

✅ API Modifications
- Impelemented UsersController to use user_id for user lookups.
- Modified routes to use resources :users, param: :user_id for consistent URL structures.
- Added error handling for not-found resources.
- Refactored controller specs to align with the new parameter structure.

📘 Documentation
- Added OpenAPI specs for all user-related endpoints.
- Integrated Swagger UI for interactive documentation at /api-docs.
- Configured Swagger to display accurate request/response schemas.

🏢 Multi-Tenancy Improvements
- Ensured tenant scoping works with the new user_id parameter.
- Updated tests to correctly handle tenant context setup.

🧪 Testing Instructions
- Run the test suite: bundle exec rspec
- Start the Rails server: rails s
- Visit /api-docs to view the Swagger UI
- Manually test API endpoints using user_id in the request paths