### PR TITLE
Allow rerun of seed to get API keys for simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Finished creating clients
 # The API should now be available at http://localhost:3000
 
 # To run the API simulation (optional)
-`API_URL=http://localhost:3000 CLIENT1_TOKEN=token_1  CLIENT2_TOKEN=token_2 ruby loyalty_api_simulation.rb`
+API_URL=http://localhost:3000 CLIENT1_TOKEN=token_1  CLIENT2_TOKEN=token_2 ruby loyalty_api_simulation.rb
 ```
 
 To view logs:

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -25,7 +25,7 @@ clients.each do |client_attrs|
     client.save!
     puts "Created client #{client.name}, subdmain: #{client.subdmain} with token: #{client.api_token}"
   else
-    puts "Client #{client.name} already exists"
+    puts "Client #{client.name} already exists, #{client.subdomain} with token: #{client.api_token}"
   end
 end
 


### PR DESCRIPTION
If the seed is already run and API key is lost, developer can re run the seed to get the API keys and try simulation or stress_test